### PR TITLE
feat(auth): 회원가입 API 구현

### DIFF
--- a/src/main/java/com/prj/flashdeal/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/prj/flashdeal/domain/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.prj.flashdeal.domain.auth.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prj.flashdeal.domain.auth.dto.request.SignupRequest;
+import com.prj.flashdeal.domain.auth.dto.response.SignupResponse;
+import com.prj.flashdeal.domain.auth.service.AuthService;
+import com.prj.flashdeal.global.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
+        return ApiResponse.success(
+            HttpStatus.CREATED,
+            "회원가입이 완료되었습니다.",
+            authService.signup(request)
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/auth/dto/request/SignupRequest.java
@@ -1,0 +1,40 @@
+package com.prj.flashdeal.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수로 입력해주세요.")
+    @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()\\-_=+\\[{\\]};:'\",<.>/?]).{8,}$",
+        message = "비밀번호는 최소 8글자 이상, 대소문자 포함 영문 + 숫자 + 특수문자를 최소 1글자씩 포함해야합니다."
+    )
+    private String password;
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    private String name;
+
+    @NotBlank(message = "우편번호는 필수 입력 값입니다.")
+    private String zipcode;
+
+    @NotBlank(message = "도로명 주소는 필수 입력 값입니다.")
+    private String street;
+
+    @NotBlank(message = "상세 주소는 필수 입력 값입니다.")
+    private String detail;
+
+    @NotBlank(message = "연락처는 필수 입력 값입니다.")
+    private String phoneNumber;
+}

--- a/src/main/java/com/prj/flashdeal/domain/auth/dto/response/SignupResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/auth/dto/response/SignupResponse.java
@@ -1,0 +1,10 @@
+package com.prj.flashdeal.domain.auth.dto.response;
+
+public record SignupResponse(
+    String grantType,
+    String accessToken
+) {
+    public static SignupResponse of(String accessToken) {
+        return new SignupResponse("Bearer", accessToken);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/auth/service/AuthService.java
+++ b/src/main/java/com/prj/flashdeal/domain/auth/service/AuthService.java
@@ -1,0 +1,66 @@
+package com.prj.flashdeal.domain.auth.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prj.flashdeal.domain.auth.dto.request.SignupRequest;
+import com.prj.flashdeal.domain.auth.dto.response.SignupResponse;
+import com.prj.flashdeal.domain.member.entity.Address;
+import com.prj.flashdeal.domain.member.entity.Member;
+import com.prj.flashdeal.domain.member.exception.MemberErrorCode;
+import com.prj.flashdeal.domain.member.exception.MemberException;
+import com.prj.flashdeal.domain.member.repository.MemberRepository;
+import com.prj.flashdeal.global.security.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public SignupResponse signup(SignupRequest request) {
+
+        // 1. 이메일 중복 확인
+        if (memberRepository.existsByEmail(request.getEmail())) {
+            throw new MemberException(MemberErrorCode.ALREADY_EXISTS_EMAIL);
+        }
+
+        // 2. 비밀번호 암호화
+        String encodePassword = passwordEncoder.encode(request.getPassword());
+
+        // 3. 멤버 객체 생성
+        Member member = Member.builder()
+            .email(request.getEmail())
+            .password(encodePassword)
+            .name(request.getName())
+            .address(
+                Address.of(
+                    request.getZipcode(),
+                    request.getStreet(),
+                    request.getDetail()
+                )
+            )
+            .phoneNumber(request.getPhoneNumber())
+            .build();
+
+        // 4. 멤버 DB 저장
+        Member savedMember = memberRepository.save(member);
+
+        // 5. 토큰 생성
+        String accessToken = jwtUtil.createToken(
+            savedMember.getId(),
+            savedMember.getEmail(),
+            savedMember.getName(),
+            savedMember.getRole()
+        );
+
+        // 6. 결과 반환
+        return SignupResponse.of(accessToken);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/entity/Address.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/entity/Address.java
@@ -1,0 +1,29 @@
+package com.prj.flashdeal.domain.member.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+    private String zipcode;
+    private String street;
+    private String detail;
+
+    private Address(String zipcode, String street, String detail) {
+        this.zipcode = zipcode;
+        this.street = street;
+        this.detail = detail;
+    }
+
+    public static Address of(String zipcode, String street, String detail) {
+        return new Address(
+            zipcode,
+            street,
+            detail
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/entity/Member.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/entity/Member.java
@@ -1,0 +1,69 @@
+package com.prj.flashdeal.domain.member.entity;
+
+import com.prj.flashdeal.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email; // 이메일
+
+    @Column(nullable = false)
+    private String password; // 비밀번호
+
+    @Column(nullable = false)
+    private String name; // 사용자 이름
+
+    @Embedded
+    private Address address;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberStatus status;
+
+    @Override
+    public void delete() {
+        super.delete();
+        this.status = MemberStatus.WITHDRAWN;
+    }
+
+    @Builder
+    private Member(String email, String password, String name, Address address, String phoneNumber) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.address = address;
+        this.phoneNumber = phoneNumber;
+        this.role = Role.USER;
+        this.status = MemberStatus.ACTIVE;
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/entity/MemberStatus.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/entity/MemberStatus.java
@@ -1,0 +1,16 @@
+package com.prj.flashdeal.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberStatus {
+
+    ACTIVE("활동"),       // 활동중인 정상 회원
+    DORMANT("휴면"),      // 1년 이상 미접속하여 휴면 처리된 회원
+    WITHDRAWN("탈퇴"),    // 스스로 탈퇴한 회원
+    BANNED("정지");       // 관리자에 의해 정지된 회원
+
+    private final String description;
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/entity/Role.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/entity/Role.java
@@ -1,0 +1,17 @@
+package com.prj.flashdeal.domain.member.entity;
+
+import java.util.Arrays;
+
+import com.prj.flashdeal.domain.member.exception.MemberErrorCode;
+import com.prj.flashdeal.domain.member.exception.MemberException;
+
+public enum Role {
+    USER, ADMIN;
+
+    public static Role of(String role) {
+        return Arrays.stream(Role.values())
+            .filter(r -> r.name().equalsIgnoreCase(role))
+            .findFirst()
+            .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_USER_ROLE));
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/exception/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package com.prj.flashdeal.domain.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    INVALID_USER_ROLE("유효하지 않은 유저 권한입니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_EXISTS_EMAIL("이미 존재하는 이메일입니다.", HttpStatus.CONFLICT);
+
+    private final String message;
+    private final HttpStatus status;
+
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/exception/MemberException.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package com.prj.flashdeal.domain.member.exception;
+
+import com.prj.flashdeal.global.exception.CustomException;
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+public class MemberException extends CustomException {
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.prj.flashdeal.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prj.flashdeal.domain.member.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/prj/flashdeal/global/config/PersistenceConfig.java
+++ b/src/main/java/com/prj/flashdeal/global/config/PersistenceConfig.java
@@ -1,0 +1,9 @@
+package com.prj.flashdeal.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class PersistenceConfig {
+}

--- a/src/main/java/com/prj/flashdeal/global/entity/BaseEntity.java
+++ b/src/main/java/com/prj/flashdeal/global/entity/BaseEntity.java
@@ -1,0 +1,34 @@
+package com.prj.flashdeal.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    // soft delete 메서드
+    public void delete() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/com/prj/flashdeal/global/security/JwtFilter.java
+++ b/src/main/java/com/prj/flashdeal/global/security/JwtFilter.java
@@ -41,7 +41,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // 2. 토큰이 존재하고, 'Bearer '로 시작하는 경우에만 인증 절차를 진행합니다.
         if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith("Bearer ")) {
-            String jwt = jwtUtil.substringToken(authorizationHeader);
+            String jwt = jwtUtil.resolveToken(authorizationHeader);
 
             try {
                 // 3. 토큰이 유효하면, Claims를 추출하고 인증 객체를 만들어 SecurityContext에 저장합니다.

--- a/src/main/java/com/prj/flashdeal/global/security/JwtUtil.java
+++ b/src/main/java/com/prj/flashdeal/global/security/JwtUtil.java
@@ -34,26 +34,24 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String createToken(Long userId, String email, String nickname , Role role) {
+    public String createToken(Long userId, String email, String name , Role role) {
         Date date = new Date();
 
-        return BEARER_PREFIX +
-                Jwts.builder()
-                        .setSubject(String.valueOf(userId))
-                        .claim("email", email)
-                        .claim("nickname", nickname)
-                        .claim("userRole", role)
-                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
-                        .setIssuedAt(date) // 발급일
-                        .signWith(key, signatureAlgorithm) // 암호화 알고리즘
-                        .compact();
+        return Jwts.builder()
+            .setSubject(String.valueOf(userId))
+            .claim("email", email)
+            .claim("name", name)
+            .claim("role", role.name())
+            .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+            .setIssuedAt(date)
+            .signWith(key, signatureAlgorithm)
+            .compact();
     }
 
-    public String substringToken(String tokenValue) {
+    public String resolveToken(String tokenValue) {
         if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
             return tokenValue.substring(7);
         }
-
         return null;
     }
 


### PR DESCRIPTION
## 주요 변경 사항
1. 회원가입 API 구현 (POST /api/auth/signup)
- 이메일 중복 확인
- PasswordEncoder를 활용한 비밀번호 암호화
- Member 엔티티 및 저장
- 회원가입 성공 시, 즉시 로그인 처리를 위해 응답으로 AccessToken 반환