### PR TITLE
Feat(product): 관리자용 상품 관리 API 구현

### DIFF
--- a/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
@@ -69,6 +69,17 @@ public class AdminProductController {
         );
     }
 
+    @GetMapping("/{productId}")
+    public ResponseEntity<ApiResponse<ProductResponse>> getProductForAdmin(
+        @PathVariable Long productId
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "관리자용 상품 상세 조회에 성공하였습니다.",
+            productService.getProductForAdmin(productId)
+        );
+    }
+
     @PatchMapping("/{productId}")
     public ResponseEntity<ApiResponse<ProductResponse>> updateProduct(
         @PathVariable Long productId,

--- a/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
@@ -1,8 +1,13 @@
 package com.prj.flashdeal.domain.product.controller;
 
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,11 +16,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.request.ProductSearchCondForAdmin;
 import com.prj.flashdeal.domain.product.dto.request.ProductUpdateRequest;
 import com.prj.flashdeal.domain.product.dto.request.StockAddRequest;
 import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
+import com.prj.flashdeal.domain.product.dto.response.ProductSummaryResponse;
 import com.prj.flashdeal.domain.product.service.ProductService;
 import com.prj.flashdeal.global.response.ApiResponse;
+import com.prj.flashdeal.global.response.PageResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +54,18 @@ public class AdminProductController {
             HttpStatus.OK,
             "재고가 추가되었습니다.",
             productService.addStock(productId, request)
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<ProductSummaryResponse>>> searchProductsForAdmin(
+        @ModelAttribute ProductSearchCondForAdmin cond,
+        @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "상품 검색이 완료되었습니다.",
+            productService.searchProductsForAdmin(cond, pageable)
         );
     }
 

--- a/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
@@ -1,0 +1,34 @@
+package com.prj.flashdeal.domain.product.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
+import com.prj.flashdeal.domain.product.service.ProductService;
+import com.prj.flashdeal.global.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/products")
+public class AdminProductController {
+
+    private final ProductService productService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ProductResponse>> createProduct(
+        @Valid @RequestBody ProductCreateRequest request) {
+        return ApiResponse.success(
+            HttpStatus.CREATED,
+            "상품 등록이 완료되었습니다.",
+            productService.createProduct(request)
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
@@ -2,6 +2,7 @@ package com.prj.flashdeal.domain.product.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,6 +58,19 @@ public class AdminProductController {
             HttpStatus.OK,
             "상품 수정이 완료되었습니다.",
             productService.updateProduct(productId, request)
+        );
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ApiResponse<Void>> deleteProduct(
+        @PathVariable Long productId
+    ) {
+        productService.deleteProduct(productId);
+
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "상품이 삭제되었습니다.",
+            null
         );
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
@@ -2,12 +2,14 @@ package com.prj.flashdeal.domain.product.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.request.StockAddRequest;
 import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
 import com.prj.flashdeal.domain.product.service.ProductService;
 import com.prj.flashdeal.global.response.ApiResponse;
@@ -29,6 +31,18 @@ public class AdminProductController {
             HttpStatus.CREATED,
             "상품 등록이 완료되었습니다.",
             productService.createProduct(request)
+        );
+    }
+
+    @PostMapping("/{productId}/stock")
+    public ResponseEntity<ApiResponse<ProductResponse>> addStock(
+        @PathVariable Long productId,
+        @Valid @RequestBody StockAddRequest request
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "재고가 추가되었습니다.",
+            productService.addStock(productId, request)
         );
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/controller/AdminProductController.java
@@ -2,6 +2,7 @@ package com.prj.flashdeal.domain.product.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.request.ProductUpdateRequest;
 import com.prj.flashdeal.domain.product.dto.request.StockAddRequest;
 import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
 import com.prj.flashdeal.domain.product.service.ProductService;
@@ -43,6 +45,18 @@ public class AdminProductController {
             HttpStatus.OK,
             "재고가 추가되었습니다.",
             productService.addStock(productId, request)
+        );
+    }
+
+    @PatchMapping("/{productId}")
+    public ResponseEntity<ApiResponse<ProductResponse>> updateProduct(
+        @PathVariable Long productId,
+        @RequestBody ProductUpdateRequest request
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "상품 수정이 완료되었습니다.",
+            productService.updateProduct(productId, request)
         );
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/dto/request/ProductCreateRequest.java
@@ -1,0 +1,22 @@
+package com.prj.flashdeal.domain.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductCreateRequest {
+
+    @NotBlank(message = "상품 명은 필수 입력 값입니다.")
+    private String name;
+
+    @NotBlank(message = "상품 설명은 필수 입력 값입니다.")
+    private String description;
+
+    @NotNull(message = "상품 가격은 필수 입력 값입니다.")
+    @Positive(message = "상품 가격은 0보다 커야 합니다.")
+    private Integer price;
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/dto/request/ProductSearchCondForAdmin.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/dto/request/ProductSearchCondForAdmin.java
@@ -1,0 +1,29 @@
+package com.prj.flashdeal.domain.product.dto.request;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.prj.flashdeal.domain.product.entity.ProductStatus;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ProductSearchCondForAdmin {
+
+    private String productName;
+
+    private Integer minPrice;
+    private Integer maxPrice;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    private ProductStatus status;
+
+    private Boolean isDeleted;
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/dto/request/ProductUpdateRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/dto/request/ProductUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.prj.flashdeal.domain.product.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductUpdateRequest {
+
+    private String name;
+    private String description;
+    private Integer price;
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/dto/request/StockAddRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/dto/request/StockAddRequest.java
@@ -1,0 +1,15 @@
+package com.prj.flashdeal.domain.product.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StockAddRequest {
+
+    @NotNull(message = "수량은 필수 입력 값입니다.")
+    @Positive(message = "수량은 0보다 커야합니다.")
+    private Integer quantity;
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/dto/response/ProductResponse.java
@@ -1,0 +1,24 @@
+package com.prj.flashdeal.domain.product.dto.response;
+
+import com.prj.flashdeal.domain.product.entity.Product;
+import com.prj.flashdeal.domain.product.entity.ProductStatus;
+
+public record ProductResponse(
+    Long productId,
+    String name,
+    String description,
+    Integer price,
+    Integer stockQuantity,
+    ProductStatus status
+) {
+    public static ProductResponse from(Product product) {
+        return new ProductResponse(
+            product.getId(),
+            product.getName(),
+            product.getDescription(),
+            product.getPrice(),
+            product.getStockQuantity(),
+            product.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/dto/response/ProductSummaryResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/dto/response/ProductSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.prj.flashdeal.domain.product.dto.response;
+
+import com.prj.flashdeal.domain.product.entity.ProductStatus;
+
+public record ProductSummaryResponse(
+    Long productId,
+    String name,
+    ProductStatus status
+) {}

--- a/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
@@ -71,4 +71,22 @@ public class Product extends BaseEntity {
             this.status = ProductStatus.ON_SALE;
         }
     }
+
+    public void updateInfo(String name, String description, Integer price) {
+        if (name != null){
+            if (name.isBlank()) {
+                throw new ProductException(ProductErrorCode.BLANK_PRODUCT_NAME);
+            }
+            this.name = name;
+        }
+        if (description != null){
+            this.description = description;
+        }
+        if (price != null) {
+            if (price <= 0) {
+                throw new ProductException(ProductErrorCode.INVALID_PRICE);
+            }
+            this.price = price;
+        }
+    }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
@@ -60,4 +60,15 @@ public class Product extends BaseEntity {
         this.stockQuantity = 0;
         this.status = ProductStatus.PREPARING;
     }
+
+    public void addStock(Integer quantity) {
+        if (quantity <= 0) {
+            throw new ProductException(ProductErrorCode.INVALID_STOCK_QUANTITY);
+        }
+        this.stockQuantity += quantity;
+
+        if (this.status == ProductStatus.PREPARING || this.status == ProductStatus.SOLD_OUT) {
+            this.status = ProductStatus.ON_SALE;
+        }
+    }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
@@ -1,0 +1,63 @@
+package com.prj.flashdeal.domain.product.entity;
+
+import com.prj.flashdeal.domain.product.exception.ProductErrorCode;
+import com.prj.flashdeal.domain.product.exception.ProductException;
+import com.prj.flashdeal.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product")
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name; // 상품 이름
+
+    @Column(nullable = false)
+    private String description; // 상품 설명
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private Integer stockQuantity; // 상품 재고
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProductStatus status; // 상품 상태(판매 준비중, 판매중, 품절)
+
+    @Override
+    public void delete() {
+        if (this.stockQuantity > 0) {
+            throw new ProductException(ProductErrorCode.STOCK_REMAINS);
+        }
+        super.delete();
+    }
+
+    @Builder
+    private Product(String name, String description, Integer price) {
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.stockQuantity = 0;
+        this.status = ProductStatus.PREPARING;
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/entity/ProductStatus.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/entity/ProductStatus.java
@@ -1,0 +1,15 @@
+package com.prj.flashdeal.domain.product.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductStatus {
+
+    PREPARING("판매 준비중"),
+    ON_SALE("판매중"),
+    SOLD_OUT("품절");
+
+    private final String description;
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
@@ -11,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
 
-    STOCK_REMAINS("재고가 남아있어서 삭제가 불가능합니다.", HttpStatus.CONFLICT);
+    STOCK_REMAINS("재고가 남아있어서 삭제가 불가능합니다.", HttpStatus.CONFLICT),
+    PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_STOCK_QUANTITY("재고 수량은 0보다 커야합니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
@@ -1,0 +1,19 @@
+package com.prj.flashdeal.domain.product.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+
+    STOCK_REMAINS("재고가 남아있어서 삭제가 불가능합니다.", HttpStatus.CONFLICT);
+
+    private final String message;
+    private final HttpStatus status;
+
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
@@ -13,7 +13,9 @@ public enum ProductErrorCode implements ErrorCode {
 
     STOCK_REMAINS("재고가 남아있어서 삭제가 불가능합니다.", HttpStatus.CONFLICT),
     PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    INVALID_STOCK_QUANTITY("재고 수량은 0보다 커야합니다.", HttpStatus.BAD_REQUEST);
+    INVALID_STOCK_QUANTITY("재고 수량은 0보다 커야합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PRICE("상품 금액은 0보다 커야합니다.", HttpStatus.BAD_REQUEST),
+    BLANK_PRODUCT_NAME("상품명은 비워둘 수 없습니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/exception/ProductErrorCode.java
@@ -15,7 +15,8 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_NOT_FOUND("상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_STOCK_QUANTITY("재고 수량은 0보다 커야합니다.", HttpStatus.BAD_REQUEST),
     INVALID_PRICE("상품 금액은 0보다 커야합니다.", HttpStatus.BAD_REQUEST),
-    BLANK_PRODUCT_NAME("상품명은 비워둘 수 없습니다.", HttpStatus.BAD_REQUEST);
+    BLANK_PRODUCT_NAME("상품명은 비워둘 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_DELETED_PRODUCT("이미 삭제된 상품입니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/prj/flashdeal/domain/product/exception/ProductException.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/exception/ProductException.java
@@ -1,0 +1,10 @@
+package com.prj.flashdeal.domain.product.exception;
+
+import com.prj.flashdeal.global.exception.CustomException;
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+public class ProductException extends CustomException {
+    public ProductException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/repository/ProductRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.prj.flashdeal.domain.product.entity.Product;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.prj.flashdeal.domain.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prj.flashdeal.domain.product.entity.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/repository/ProductRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.prj.flashdeal.domain.product.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.prj.flashdeal.domain.product.dto.request.ProductSearchCondForAdmin;
+import com.prj.flashdeal.domain.product.dto.response.ProductSummaryResponse;
+
+public interface ProductRepositoryCustom {
+
+    Page<ProductSummaryResponse> searchProductsForAdmin(ProductSearchCondForAdmin cond, Pageable pageable);
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/repository/impl/ProductRepositoryCustomImpl.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/repository/impl/ProductRepositoryCustomImpl.java
@@ -1,0 +1,105 @@
+package com.prj.flashdeal.domain.product.repository.impl;
+
+import static com.prj.flashdeal.domain.product.entity.QProduct.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.prj.flashdeal.domain.product.dto.request.ProductSearchCondForAdmin;
+import com.prj.flashdeal.domain.product.dto.response.ProductSummaryResponse;
+import com.prj.flashdeal.domain.product.entity.ProductStatus;
+import com.prj.flashdeal.domain.product.repository.ProductRepositoryCustom;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ProductSummaryResponse> searchProductsForAdmin(ProductSearchCondForAdmin cond, Pageable pageable) {
+
+        List<ProductSummaryResponse> productSummaryResponseList = queryFactory
+            .select(Projections.constructor(ProductSummaryResponse.class,
+                product.id,
+                product.name,
+                product.status))
+            .from(product)
+            .where(
+                productNameContains(cond.getProductName()),
+                priceGoe(cond.getMinPrice()),
+                priceLoe(cond.getMaxPrice()),
+                registeredAtGoe(cond.getStartDate()),
+                registeredAtLoe(cond.getEndDate()),
+                statusEq(cond.getStatus()),
+                isDeletedEq(cond.getIsDeleted())
+            )
+            .orderBy(product.createdAt.asc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(product.count())
+            .from(product)
+            .where(
+                productNameContains(cond.getProductName()),
+                priceGoe(cond.getMinPrice()),
+                priceLoe(cond.getMaxPrice()),
+                registeredAtGoe(cond.getStartDate()),
+                registeredAtLoe(cond.getEndDate()),
+                statusEq(cond.getStatus()),
+                isDeletedEq(cond.getIsDeleted())
+            );
+
+        return PageableExecutionUtils.getPage(productSummaryResponseList, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression productNameContains(String productName) {
+        if (!StringUtils.hasText(productName)) {
+            return null;
+        }
+        return product.name.containsIgnoreCase(productName);
+    }
+
+    private BooleanExpression priceGoe(Integer minPrice) {
+        return minPrice != null ? product.price.goe(minPrice) : null;
+    }
+
+    private BooleanExpression priceLoe(Integer maxPrice) {
+        return maxPrice != null ? product.price.loe(maxPrice) : null;
+    }
+
+    private BooleanExpression registeredAtGoe(LocalDate startDate) {
+        return startDate != null ? product.createdAt.goe(startDate.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression registeredAtLoe(LocalDate endDate) {
+        return endDate != null ? product.createdAt.loe(endDate.atTime(LocalTime.MAX)) : null;
+    }
+
+    private BooleanExpression statusEq(ProductStatus status) {
+        return status != null ? product.status.eq(status) : null;
+    }
+
+    private BooleanExpression isDeletedEq(Boolean isDeleted) {
+        if (isDeleted == null) {
+            return null; // isDeleted 파라미터가 없으면, 전체 조회
+        }
+        return isDeleted ? product.isDeleted.isTrue() : product.isDeleted.isFalse();
+    }
+}
+

--- a/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.request.ProductUpdateRequest;
 import com.prj.flashdeal.domain.product.dto.request.StockAddRequest;
 import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
 import com.prj.flashdeal.domain.product.entity.Product;
@@ -34,11 +35,29 @@ public class ProductService {
 
     @Transactional
     public ProductResponse addStock(Long productId, StockAddRequest request) {
-        Product product = productRepository.findById(productId)
-            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+        Product product = getProduct(productId);
 
         product.addStock(request.getQuantity());
 
         return ProductResponse.from(product);
+    }
+
+    @Transactional
+    public ProductResponse updateProduct(Long productId, ProductUpdateRequest request) {
+        Product product = getProduct(productId);
+
+        product.updateInfo(
+            request.getName(),
+            request.getDescription(),
+            request.getPrice()
+        );
+
+        return ProductResponse.from(product);
+    }
+
+    // ---------------- private 헬퍼 메서드 ----------------
+    private Product getProduct(Long productId) {
+        return productRepository.findById(productId)
+            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
@@ -1,16 +1,20 @@
 package com.prj.flashdeal.domain.product.service;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.request.ProductSearchCondForAdmin;
 import com.prj.flashdeal.domain.product.dto.request.ProductUpdateRequest;
 import com.prj.flashdeal.domain.product.dto.request.StockAddRequest;
 import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
+import com.prj.flashdeal.domain.product.dto.response.ProductSummaryResponse;
 import com.prj.flashdeal.domain.product.entity.Product;
 import com.prj.flashdeal.domain.product.exception.ProductErrorCode;
 import com.prj.flashdeal.domain.product.exception.ProductException;
 import com.prj.flashdeal.domain.product.repository.ProductRepository;
+import com.prj.flashdeal.global.response.PageResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -60,6 +64,11 @@ public class ProductService {
         Product product = getProduct(productId);
 
         product.delete();
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<ProductSummaryResponse> searchProductsForAdmin(ProductSearchCondForAdmin cond, Pageable pageable) {
+        return new PageResponse<>(productRepository.searchProductsForAdmin(cond, pageable));
     }
 
     // ---------------- private 헬퍼 메서드 ----------------

--- a/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
@@ -55,9 +55,22 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
+    @Transactional
+    public void deleteProduct(Long productId) {
+        Product product = getProduct(productId);
+
+        product.delete();
+    }
+
     // ---------------- private 헬퍼 메서드 ----------------
     private Product getProduct(Long productId) {
-        return productRepository.findById(productId)
+        Product product = productRepository.findById(productId)
             .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (product.getIsDeleted()) {
+            throw new ProductException(ProductErrorCode.ALREADY_DELETED_PRODUCT);
+        }
+
+        return product;
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
@@ -1,0 +1,31 @@
+package com.prj.flashdeal.domain.product.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
+import com.prj.flashdeal.domain.product.entity.Product;
+import com.prj.flashdeal.domain.product.repository.ProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public ProductResponse createProduct(ProductCreateRequest request) {
+        Product product = Product.builder()
+            .name(request.getName())
+            .description(request.getDescription())
+            .price(request.getPrice())
+            .build();
+
+        Product savedProduct = productRepository.save(product);
+
+        return ProductResponse.from(savedProduct);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
@@ -4,8 +4,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prj.flashdeal.domain.product.dto.request.ProductCreateRequest;
+import com.prj.flashdeal.domain.product.dto.request.StockAddRequest;
 import com.prj.flashdeal.domain.product.dto.response.ProductResponse;
 import com.prj.flashdeal.domain.product.entity.Product;
+import com.prj.flashdeal.domain.product.exception.ProductErrorCode;
+import com.prj.flashdeal.domain.product.exception.ProductException;
 import com.prj.flashdeal.domain.product.repository.ProductRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,5 +30,15 @@ public class ProductService {
         Product savedProduct = productRepository.save(product);
 
         return ProductResponse.from(savedProduct);
+    }
+
+    @Transactional
+    public ProductResponse addStock(Long productId, StockAddRequest request) {
+        Product product = productRepository.findById(productId)
+            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        product.addStock(request.getQuantity());
+
+        return ProductResponse.from(product);
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
@@ -46,6 +46,18 @@ public class ProductService {
         return ProductResponse.from(product);
     }
 
+    @Transactional(readOnly = true)
+    public PageResponse<ProductSummaryResponse> searchProductsForAdmin(ProductSearchCondForAdmin cond, Pageable pageable) {
+        return new PageResponse<>(productRepository.searchProductsForAdmin(cond, pageable));
+    }
+
+    @Transactional(readOnly = true)
+    public ProductResponse getProductForAdmin(Long productId) {
+        Product product = getProduct(productId);
+
+        return ProductResponse.from(product);
+    }
+
     @Transactional
     public ProductResponse updateProduct(Long productId, ProductUpdateRequest request) {
         Product product = getProduct(productId);
@@ -64,11 +76,6 @@ public class ProductService {
         Product product = getProduct(productId);
 
         product.delete();
-    }
-
-    @Transactional(readOnly = true)
-    public PageResponse<ProductSummaryResponse> searchProductsForAdmin(ProductSearchCondForAdmin cond, Pageable pageable) {
-        return new PageResponse<>(productRepository.searchProductsForAdmin(cond, pageable));
     }
 
     // ---------------- private 헬퍼 메서드 ----------------

--- a/src/main/java/com/prj/flashdeal/global/security/JwtFilter.java
+++ b/src/main/java/com/prj/flashdeal/global/security/JwtFilter.java
@@ -47,7 +47,7 @@ public class JwtFilter extends OncePerRequestFilter {
                 // 3. 토큰이 유효하면, Claims를 추출하고 인증 객체를 만들어 SecurityContext에 저장합니다.
                 Claims claims = jwtUtil.extractClaims(jwt);
 
-                Role userRole = Role.valueOf(claims.get("userRole", String.class));
+                Role userRole = Role.valueOf(claims.get("role", String.class));
                 long userId = Long.parseLong(claims.getSubject());
 
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(


### PR DESCRIPTION
## 주요 기능
1. Create (생성)
•POST /api/admin/products: 상품의 기본 정보를 등록합니다. (PREPARING 상태, 재고 0)
•POST /api/admin/products/{id}/stock: 특정 상품에 재고를 추가하고, 판매 상태(ON_SALE)로 전환합니다.

2. Read (조회)
•GET /api/admin/products: Querydsl을 이용한 동적 검색 및 페이지네이션을 지원합니다.
•GET /api/admin/products/{id}: 특정 상품의 모든 상세 정보를 조회합니다.

3. Update (수정)
•PATCH /api/admin/products/{id}: 특정 상품의 정보(이름, 설명, 가격)를 부분적으로 수정합니다.

4. Delete (삭제)
•DELETE /api/admin/products/{id}: 재고가 없을 경우에만 상품을 논리적으로 삭제(Soft Delete)합니다.