### PR TITLE
feat(cart): 장바구니 API 구현

### DIFF
--- a/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
@@ -3,6 +3,7 @@ package com.prj.flashdeal.domain.cart.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.prj.flashdeal.domain.cart.dto.request.CartItemAddRequest;
 import com.prj.flashdeal.domain.cart.dto.response.CartItemResponse;
+import com.prj.flashdeal.domain.cart.dto.response.CartResponse;
 import com.prj.flashdeal.domain.cart.service.CartService;
 import com.prj.flashdeal.global.response.ApiResponse;
 import com.prj.flashdeal.global.security.dto.UserPrincipal;
@@ -33,6 +35,16 @@ public class CartController {
             HttpStatus.CREATED,
             "장바구니에 상품이 추가되었습니다.",
             cartService.addCartItem(userPrincipal.getUserId(), request)
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CartResponse>> getCartItems(
+        @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "장바구니 조회가 완료되었습니다.",
+            cartService.getCartItems(userPrincipal.getUserId())
         );
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
@@ -78,4 +78,17 @@ public class CartController {
             null
         );
     }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> clearCart(
+        @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        cartService.clearCart(userPrincipal.getUserId());
+
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "장바구니가 비워졌습니다.",
+            null
+        );
+    }
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
@@ -3,6 +3,7 @@ package com.prj.flashdeal.domain.cart.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -61,6 +62,20 @@ public class CartController {
             HttpStatus.OK,
             "장바구니 상품 수량이 수정되었습니다.",
             cartService.updateCartItemQuantity(userPrincipal.getUserId(), cartItemId, request)
+        );
+    }
+
+    @DeleteMapping("/{cartItemId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCartItem(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @PathVariable Long cartItemId
+    ) {
+        cartService.deleteCartItem(userPrincipal.getUserId(), cartItemId);
+
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "장바구니 상품이 삭제되었습니다.",
+            null
         );
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/controller/CartController.java
@@ -4,12 +4,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prj.flashdeal.domain.cart.dto.request.CartItemAddRequest;
+import com.prj.flashdeal.domain.cart.dto.request.CartItemUpdateRequest;
 import com.prj.flashdeal.domain.cart.dto.response.CartItemResponse;
 import com.prj.flashdeal.domain.cart.dto.response.CartResponse;
 import com.prj.flashdeal.domain.cart.service.CartService;
@@ -45,6 +48,19 @@ public class CartController {
             HttpStatus.OK,
             "장바구니 조회가 완료되었습니다.",
             cartService.getCartItems(userPrincipal.getUserId())
+        );
+    }
+
+    @PatchMapping("/{cartItemId}")
+    public ResponseEntity<ApiResponse<CartItemResponse>> updateCartItemQuantity(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @PathVariable Long cartItemId,
+        @Valid @RequestBody CartItemUpdateRequest request
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "장바구니 상품 수량이 수정되었습니다.",
+            cartService.updateCartItemQuantity(userPrincipal.getUserId(), cartItemId, request)
         );
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/dto/request/CartItemUpdateRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/dto/request/CartItemUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.prj.flashdeal.domain.cart.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CartItemUpdateRequest {
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    private Integer quantity;
+}

--- a/src/main/java/com/prj/flashdeal/domain/cart/dto/response/CartItemResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/dto/response/CartItemResponse.java
@@ -3,7 +3,7 @@ package com.prj.flashdeal.domain.cart.dto.response;
 import com.prj.flashdeal.domain.cart.entity.CartItem;
 
 public record CartItemResponse(
-    Long CartItemId,
+    Long cartItemId,
     Long productId,
     String productName,
     int price,

--- a/src/main/java/com/prj/flashdeal/domain/cart/dto/response/CartResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/dto/response/CartResponse.java
@@ -1,0 +1,23 @@
+package com.prj.flashdeal.domain.cart.dto.response;
+
+import java.util.List;
+
+
+public record CartResponse(
+    Long memberId,
+    List<CartItemResponse> items,
+    Integer totalPrice,
+    Integer totalQuantity
+) {
+    public static CartResponse of(Long memberId, List<CartItemResponse> items) {
+        int totalPrice = items.stream()
+            .mapToInt(CartItemResponse::totalPrice)
+            .sum();
+
+        int totalQuantity = items.stream()
+            .mapToInt(CartItemResponse::quantity)
+            .sum();
+
+        return new CartResponse(memberId, items, totalPrice, totalQuantity);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/entity/CartItem.java
@@ -63,4 +63,11 @@ public class CartItem extends BaseTimeEntity {
     public int calculateItemTotalPrice() {
         return this.price * this.quantity;
     }
+
+    public void updateQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new CartException(CartErrorCode.INVALID_QUANTITY);
+        }
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/exception/CartErrorCode.java
@@ -11,7 +11,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CartErrorCode implements ErrorCode {
 
-    INVALID_QUANTITY("수량은 1개 이상이어야 합니다.", HttpStatus.BAD_REQUEST);
+    INVALID_QUANTITY("수량은 1개 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+    CART_ITEM_NOT_FOUND("장바구니 상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_CART_ITEM("본인의 장바구니 상품만 수정할 수 있습니다.", HttpStatus.FORBIDDEN);
 
 
     private final String message;

--- a/src/main/java/com/prj/flashdeal/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/repository/CartItemRepository.java
@@ -3,6 +3,9 @@ package com.prj.flashdeal.domain.cart.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.prj.flashdeal.domain.cart.entity.CartItem;
 import com.prj.flashdeal.domain.member.entity.Member;
@@ -10,4 +13,8 @@ import com.prj.flashdeal.domain.product.entity.Product;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long>, CartItemRepositoryCustom {
     Optional<CartItem> findByMemberAndProduct(Member member, Product product);
+
+    @Modifying
+    @Query("DELETE FROM CartItem ci WHERE ci.member = :member")
+    void deleteAllByMember(@Param("member") Member member);
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/repository/CartItemRepository.java
@@ -8,6 +8,6 @@ import com.prj.flashdeal.domain.cart.entity.CartItem;
 import com.prj.flashdeal.domain.member.entity.Member;
 import com.prj.flashdeal.domain.product.entity.Product;
 
-public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+public interface CartItemRepository extends JpaRepository<CartItem, Long>, CartItemRepositoryCustom {
     Optional<CartItem> findByMemberAndProduct(Member member, Product product);
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/repository/CartItemRepositoryCustom.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/repository/CartItemRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.prj.flashdeal.domain.cart.repository;
+
+import java.util.List;
+
+import com.prj.flashdeal.domain.cart.dto.response.CartItemResponse;
+import com.prj.flashdeal.domain.member.entity.Member;
+
+public interface CartItemRepositoryCustom {
+    List<CartItemResponse> findCartItemsByMember(Member member);
+}

--- a/src/main/java/com/prj/flashdeal/domain/cart/repository/impl/CartItemRepositoryCustomImpl.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/repository/impl/CartItemRepositoryCustomImpl.java
@@ -1,0 +1,41 @@
+package com.prj.flashdeal.domain.cart.repository.impl;
+
+import static com.prj.flashdeal.domain.cart.entity.QCartItem.*;
+import static com.prj.flashdeal.domain.product.entity.QProduct.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.prj.flashdeal.domain.cart.dto.response.CartItemResponse;
+import com.prj.flashdeal.domain.cart.repository.CartItemRepositoryCustom;
+import com.prj.flashdeal.domain.member.entity.Member;
+import com.prj.flashdeal.domain.product.entity.QProduct;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CartItemRepositoryCustomImpl implements CartItemRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CartItemResponse> findCartItemsByMember(Member member) {
+        return queryFactory
+            .select(Projections.constructor(CartItemResponse.class,
+                cartItem.id,
+                product.id,
+                product.name,
+                cartItem.price,
+                cartItem.quantity,
+                cartItem.price.multiply(cartItem.quantity))
+            )
+            .from(cartItem)
+            .join(cartItem.product, product)
+            .where(cartItem.member.eq(member))
+            .fetch();
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
@@ -1,5 +1,6 @@
 package com.prj.flashdeal.domain.cart.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -7,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.prj.flashdeal.domain.cart.dto.request.CartItemAddRequest;
 import com.prj.flashdeal.domain.cart.dto.response.CartItemResponse;
+import com.prj.flashdeal.domain.cart.dto.response.CartResponse;
 import com.prj.flashdeal.domain.cart.entity.CartItem;
 import com.prj.flashdeal.domain.cart.repository.CartItemRepository;
 import com.prj.flashdeal.domain.member.entity.Member;
@@ -35,6 +37,16 @@ public class CartService {
         return CartItemResponse.from(cartItem);
     }
 
+    @Transactional(readOnly = true)
+    public CartResponse getCartItems(Long memberId) {
+
+        Member member = memberService.getMember(memberId);
+
+        List<CartItemResponse> cartItems = cartItemRepository.findCartItemsByMember(member);
+
+        return CartResponse.of(member.getId(), cartItems);
+    }
+
     // ---------------- private 헬퍼 메서드 ----------------
     private CartItem findOrCreateCartItem(Member member, Product product, int quantity) {
         return cartItemRepository.findByMemberAndProduct(member, product)
@@ -51,5 +63,4 @@ public class CartService {
                 return cartItemRepository.save(cartItem);
             });
     }
-
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
@@ -73,6 +73,13 @@ public class CartService {
         cartItemRepository.delete(cartItem);
     }
 
+    @Transactional
+    public void clearCart(Long memberId) {
+        Member member = memberService.getMember(memberId);
+
+        cartItemRepository.deleteAllByMember(member);
+    }
+
     // ---------------- private 헬퍼 메서드 ----------------
     private CartItem findOrCreateCartItem(Member member, Product product, int quantity) {
         return cartItemRepository.findByMemberAndProduct(member, product)

--- a/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
@@ -7,9 +7,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prj.flashdeal.domain.cart.dto.request.CartItemAddRequest;
+import com.prj.flashdeal.domain.cart.dto.request.CartItemUpdateRequest;
 import com.prj.flashdeal.domain.cart.dto.response.CartItemResponse;
 import com.prj.flashdeal.domain.cart.dto.response.CartResponse;
 import com.prj.flashdeal.domain.cart.entity.CartItem;
+import com.prj.flashdeal.domain.cart.exception.CartErrorCode;
+import com.prj.flashdeal.domain.cart.exception.CartException;
 import com.prj.flashdeal.domain.cart.repository.CartItemRepository;
 import com.prj.flashdeal.domain.member.entity.Member;
 import com.prj.flashdeal.domain.member.service.MemberService;
@@ -47,6 +50,19 @@ public class CartService {
         return CartResponse.of(member.getId(), cartItems);
     }
 
+    @Transactional
+    public CartItemResponse updateCartItemQuantity(Long memberId, Long cartItemId, CartItemUpdateRequest request) {
+
+        Member member = memberService.getMember(memberId);
+        CartItem cartItem = getCartItem(cartItemId);
+
+        validateCartItemOwner(cartItem, member);
+
+        cartItem.updateQuantity(request.getQuantity());
+
+        return CartItemResponse.from(cartItem);
+    }
+
     // ---------------- private 헬퍼 메서드 ----------------
     private CartItem findOrCreateCartItem(Member member, Product product, int quantity) {
         return cartItemRepository.findByMemberAndProduct(member, product)
@@ -62,5 +78,16 @@ public class CartService {
                     .build();
                 return cartItemRepository.save(cartItem);
             });
+    }
+
+    private CartItem getCartItem(Long cartItemId) {
+        return cartItemRepository.findById(cartItemId)
+            .orElseThrow(() -> new CartException(CartErrorCode.CART_ITEM_NOT_FOUND));
+    }
+
+    private void validateCartItemOwner(CartItem cartItem, Member member) {
+        if (!cartItem.getMember().getId().equals(member.getId())) {
+            throw new CartException(CartErrorCode.UNAUTHORIZED_CART_ITEM);
+        }
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
+++ b/src/main/java/com/prj/flashdeal/domain/cart/service/CartService.java
@@ -63,6 +63,16 @@ public class CartService {
         return CartItemResponse.from(cartItem);
     }
 
+    @Transactional
+    public void deleteCartItem(Long memberId, Long cartItemId) {
+        Member member = memberService.getMember(memberId);
+        CartItem cartItem = getCartItem(cartItemId);
+
+        validateCartItemOwner(cartItem, member);
+
+        cartItemRepository.delete(cartItem);
+    }
+
     // ---------------- private 헬퍼 메서드 ----------------
     private CartItem findOrCreateCartItem(Member member, Product product, int quantity) {
         return cartItemRepository.findByMemberAndProduct(member, product)


### PR DESCRIPTION
## 주요 기능

### 장바구니 상품 추가 API
#### POST /api/carts

- 상품을 장바구니에 추가합니다.
- 이미 담긴 상품인 경우 수량이 증가합니다.
- 판매중인 상품만 장바구니에 담을 수 있습니다.

### 장바구니 목록 조회 API
#### GET /api/carts

- 사용자의 장바구니 목록을 조회합니다.
- 총 가격과 총 수량이 함께 제공됩니다.
- QueryDSL을 사용한 DTO 프로젝션으로 성능을 최적화했습니다.

### 장바구니 상품 수량 수정 API
#### PATCH /api/carts/{cartItemId}

- 장바구니에 담긴 상품의 수량을 변경합니다.
- 본인의 장바구니 상품만 수정할 수 있습니다.

### 장바구니 상품 삭제 API
#### DELETE /api/carts/{cartItemId}

- 장바구니에서 특정 상품을 삭제합니다.
- 본인의 장바구니 상품만 삭제할 수 있습니다.

### 장바구니 전체 삭제 API
#### DELETE /api/carts

- 장바구니의 모든 상품을 삭제합니다.
- 주문 완료 후 장바구니를 비울 때 사용합니다.