### PR TITLE
feat: 주문(Order) 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // Oauth2.0
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
     // jwt
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/src/main/java/com/prj/flashdeal/domain/member/controller/MemberController.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/controller/MemberController.java
@@ -4,14 +4,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prj.flashdeal.domain.member.dto.request.MemberUpdateRequest;
+import com.prj.flashdeal.domain.member.dto.request.PasswordChangeRequest;
 import com.prj.flashdeal.domain.member.dto.response.MemberProfileResponse;
 import com.prj.flashdeal.domain.member.service.MemberService;
 import com.prj.flashdeal.global.response.ApiResponse;
 import com.prj.flashdeal.global.security.dto.UserPrincipal;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,13 +26,48 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    /**
+     * 프로필 조회
+     */
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MemberProfileResponse>> getMyProfile(
-        @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
         return ApiResponse.success(
             HttpStatus.OK,
             "프로필 조회에 성공하였습니다.",
             memberService.getMyProfile(userPrincipal.getUserId())
+        );
+    }
+
+    /**
+     * 회원 정보 수정
+     */
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<MemberProfileResponse>> updateMemberInfo(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @Valid @RequestBody MemberUpdateRequest request
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "회원 정보가 수정되었습니다.",
+            memberService.updateMemberInfo(userPrincipal.getUserId(), request)
+        );
+    }
+
+    /**
+     * 비밀번호 변경
+     */
+    @PatchMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @Valid @RequestBody PasswordChangeRequest request
+    ) {
+        memberService.changePassword(userPrincipal.getUserId(), request);
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "비밀번호가 변경되었습니다.",
+            null
         );
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.prj.flashdeal.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberUpdateRequest {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "우편번호는 필수입니다.")
+    private String zipcode;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String street;
+
+    @NotBlank(message = "상세주소는 필수입니다.")
+    private String detail;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phoneNumber;
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,21 @@
+package com.prj.flashdeal.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordChangeRequest {
+
+    @NotBlank(message = "현재 비밀번호는 필수입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+        message = "비밀번호는 최소 8자 이상이며, 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String newPassword;
+}

--- a/src/main/java/com/prj/flashdeal/domain/member/entity/Member.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/entity/Member.java
@@ -66,4 +66,20 @@ public class Member extends BaseEntity {
         this.role = Role.USER;
         this.status = MemberStatus.ACTIVE;
     }
+
+    /**
+     * 회원 정보 수정
+     */
+    public void updateInfo(String name, Address address, String phoneNumber) {
+        this.name = name;
+        this.address = address;
+        this.phoneNumber = phoneNumber;
+    }
+
+    /**
+     * 비밀번호 변경
+     */
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/prj/flashdeal/domain/member/service/MemberService.java
+++ b/src/main/java/com/prj/flashdeal/domain/member/service/MemberService.java
@@ -1,9 +1,13 @@
 package com.prj.flashdeal.domain.member.service;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prj.flashdeal.domain.member.dto.request.MemberUpdateRequest;
+import com.prj.flashdeal.domain.member.dto.request.PasswordChangeRequest;
 import com.prj.flashdeal.domain.member.dto.response.MemberProfileResponse;
+import com.prj.flashdeal.domain.member.entity.Address;
 import com.prj.flashdeal.domain.member.entity.Member;
 import com.prj.flashdeal.domain.member.entity.MemberStatus;
 import com.prj.flashdeal.domain.member.exception.MemberErrorCode;
@@ -17,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public MemberProfileResponse getMyProfile(Long userId) {
@@ -41,5 +46,40 @@ public class MemberService {
         }
 
         return member;
+    }
+
+    /**
+     * 회원 정보 수정
+     */
+    @Transactional
+    public MemberProfileResponse updateMemberInfo(Long userId, MemberUpdateRequest request) {
+        Member member = getMember(userId);
+
+        Address newAddress = Address.of(
+            request.getZipcode(),
+            request.getStreet(),
+            request.getDetail()
+        );
+
+        member.updateInfo(request.getName(), newAddress, request.getPhoneNumber());
+
+        return MemberProfileResponse.from(member);
+    }
+
+    /**
+     * 비밀번호 변경
+     */
+    @Transactional
+    public void changePassword(Long userId, PasswordChangeRequest request) {
+        Member member = getMember(userId);
+
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
+            throw new MemberException(MemberErrorCode.INVALID_PASSWORD);
+        }
+
+        // 새 비밀번호 암호화 후 저장
+        String encodedPassword = passwordEncoder.encode(request.getNewPassword());
+        member.changePassword(encodedPassword);
     }
 }

--- a/src/main/java/com/prj/flashdeal/domain/order/controller/AdminOrderController.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/controller/AdminOrderController.java
@@ -1,0 +1,85 @@
+package com.prj.flashdeal.domain.order.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prj.flashdeal.domain.order.dto.response.OrderResponse;
+import com.prj.flashdeal.domain.order.dto.response.OrderSummaryResponse;
+import com.prj.flashdeal.domain.order.service.OrderService;
+import com.prj.flashdeal.global.response.ApiResponse;
+import com.prj.flashdeal.global.response.PageResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/orders")
+public class AdminOrderController {
+
+    private final OrderService orderService;
+
+    /**
+     * 전체 주문 목록 조회 (관리자) - 페이징
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<OrderSummaryResponse>>> getAllOrders(
+        @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "전체 주문 목록 조회가 완료되었습니다.",
+            orderService.getAllOrders(pageable)
+        );
+    }
+
+    /**
+     * 주문 상세 조회 (관리자)
+     */
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> getOrder(
+        @PathVariable Long orderId
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "주문 상세 조회가 완료되었습니다.",
+            orderService.getOrderForAdmin(orderId)
+        );
+    }
+
+    /**
+     * 배송 시작 처리 (관리자)
+     */
+    @PatchMapping("/{orderId}/ship")
+    public ResponseEntity<ApiResponse<Void>> startShipping(
+        @PathVariable Long orderId
+    ) {
+        orderService.startShipping(orderId);
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "배송이 시작되었습니다.",
+            null
+        );
+    }
+
+    /**
+     * 배송 완료 처리 (관리자)
+     */
+    @PatchMapping("/{orderId}/deliver")
+    public ResponseEntity<ApiResponse<Void>> completeDelivery(
+        @PathVariable Long orderId
+    ) {
+        orderService.completeDelivery(orderId);
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "배송이 완료되었습니다.",
+            null
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/controller/OrderController.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/controller/OrderController.java
@@ -1,0 +1,94 @@
+package com.prj.flashdeal.domain.order.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prj.flashdeal.domain.order.dto.request.OrderCreateRequest;
+import com.prj.flashdeal.domain.order.dto.response.OrderResponse;
+import com.prj.flashdeal.domain.order.dto.response.OrderSummaryResponse;
+import com.prj.flashdeal.domain.order.service.OrderService;
+import com.prj.flashdeal.global.response.ApiResponse;
+import com.prj.flashdeal.global.response.PageResponse;
+import com.prj.flashdeal.global.security.dto.UserPrincipal;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    /**
+     * 주문 생성
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @Valid @RequestBody OrderCreateRequest request
+    ) {
+        return ApiResponse.success(
+            HttpStatus.CREATED,
+            "주문이 생성되었습니다.",
+            orderService.createOrder(userPrincipal.getUserId(), request)
+        );
+    }
+
+    /**
+     * 주문 단건 조회
+     */
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<OrderResponse>> getOrder(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @PathVariable Long orderId
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "주문 조회가 완료되었습니다.",
+            orderService.getOrder(userPrincipal.getUserId(), orderId)
+        );
+    }
+
+    /**
+     * 주문 목록 조회 - 페이징
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponse<OrderSummaryResponse>>> getOrders(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "주문 목록 조회가 완료되었습니다.",
+            orderService.getOrders(userPrincipal.getUserId(), pageable)
+        );
+    }
+
+    /**
+     * 주문 취소
+     */
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<Void>> cancelOrder(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @PathVariable Long orderId
+    ) {
+        orderService.cancelOrder(userPrincipal.getUserId(), orderId);
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "주문이 취소되었습니다.",
+            null
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/dto/request/OrderCreateRequest.java
@@ -1,0 +1,25 @@
+package com.prj.flashdeal.domain.order.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderCreateRequest {
+
+    @NotBlank(message = "수령인 이름은 필수입니다.")
+    private String recipientName;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    private String phoneNumber;
+
+    @NotBlank(message = "우편번호는 필수입니다.")
+    private String zipcode;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String street;
+
+    @NotBlank(message = "상세주소는 필수입니다.")
+    private String detail;
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/dto/response/DeliveryAddressResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/dto/response/DeliveryAddressResponse.java
@@ -1,0 +1,21 @@
+package com.prj.flashdeal.domain.order.dto.response;
+
+import com.prj.flashdeal.domain.order.entity.DeliveryAddress;
+
+public record DeliveryAddressResponse(
+    String recipientName,
+    String phoneNumber,
+    String zipcode,
+    String street,
+    String detail
+) {
+    public static DeliveryAddressResponse from(DeliveryAddress deliveryAddress) {
+        return new DeliveryAddressResponse(
+            deliveryAddress.getRecipientName(),
+            deliveryAddress.getPhoneNumber(),
+            deliveryAddress.getZipcode(),
+            deliveryAddress.getStreet(),
+            deliveryAddress.getDetail()
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/dto/response/OrderItemResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/dto/response/OrderItemResponse.java
@@ -1,0 +1,23 @@
+package com.prj.flashdeal.domain.order.dto.response;
+
+import com.prj.flashdeal.domain.order.entity.OrderItem;
+
+public record OrderItemResponse(
+    Long orderItemId,
+    Long productId,
+    String productName,
+    int price,
+    int quantity,
+    int orderPrice
+) {
+    public static OrderItemResponse from(OrderItem orderItem) {
+        return new OrderItemResponse(
+            orderItem.getId(),
+            orderItem.getProduct().getId(),
+            orderItem.getProduct().getName(),
+            orderItem.getPrice(),
+            orderItem.getQuantity(),
+            orderItem.getOrderPrice()
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/dto/response/OrderResponse.java
@@ -1,0 +1,31 @@
+package com.prj.flashdeal.domain.order.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.prj.flashdeal.domain.order.entity.Order;
+import com.prj.flashdeal.domain.order.entity.OrderStatus;
+
+public record OrderResponse(
+    Long orderId,
+    Long memberId,
+    OrderStatus status,
+    DeliveryAddressResponse deliveryAddress,
+    List<OrderItemResponse> orderItems,
+    Integer totalPrice,
+    LocalDateTime createdAt
+) {
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(
+            order.getId(),
+            order.getMember().getId(),
+            order.getStatus(),
+            DeliveryAddressResponse.from(order.getDeliveryAddress()),
+            order.getOrderItems().stream()
+                .map(OrderItemResponse::from)
+                .toList(),
+            order.getTotalPrice(),
+            order.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/dto/response/OrderSummaryResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/dto/response/OrderSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.prj.flashdeal.domain.order.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.prj.flashdeal.domain.order.entity.Order;
+import com.prj.flashdeal.domain.order.entity.OrderStatus;
+
+public record OrderSummaryResponse(
+    Long orderId,
+    OrderStatus status,
+    Integer totalPrice,
+    int itemCount,
+    LocalDateTime createdAt
+) {
+    public static OrderSummaryResponse from(Order order) {
+        return new OrderSummaryResponse(
+            order.getId(),
+            order.getStatus(),
+            order.getTotalPrice(),
+            order.getOrderItems().size(),
+            order.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/entity/DeliveryAddress.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/entity/DeliveryAddress.java
@@ -1,0 +1,60 @@
+package com.prj.flashdeal.domain.order.entity;
+
+import com.prj.flashdeal.domain.member.entity.Member;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryAddress {
+
+    private String recipientName;
+    private String phoneNumber;
+    private String zipcode;
+    private String street;
+    private String detail;
+
+    private DeliveryAddress(
+        String recipientName,
+        String phoneNumber,
+        String zipcode,
+        String street,
+        String detail
+    ) {
+        this.recipientName = recipientName;
+        this.phoneNumber = phoneNumber;
+        this.zipcode = zipcode;
+        this.street = street;
+        this.detail = detail;
+    }
+
+    public static DeliveryAddress from(Member member) {
+        return new DeliveryAddress(
+            member.getName(),
+            member.getPhoneNumber(),
+            member.getAddress().getZipcode(),
+            member.getAddress().getStreet(),
+            member.getAddress().getDetail()
+        );
+    }
+
+    public static DeliveryAddress of(
+        String recipientName,
+        String phoneNumber,
+        String zipcode,
+        String street,
+        String detail
+    ) {
+        return new DeliveryAddress(
+            recipientName,
+            phoneNumber,
+            zipcode,
+            street,
+            detail
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/entity/Order.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/entity/Order.java
@@ -1,0 +1,131 @@
+package com.prj.flashdeal.domain.order.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.prj.flashdeal.domain.member.entity.Member;
+import com.prj.flashdeal.domain.order.exception.OrderErrorCode;
+import com.prj.flashdeal.domain.order.exception.OrderException;
+import com.prj.flashdeal.domain.payment.entity.Payment;
+import com.prj.flashdeal.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class Order extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Payment payment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Embedded
+    private DeliveryAddress deliveryAddress;
+
+    @Column(nullable = false)
+    private Integer totalPrice;
+
+    @Builder
+    private Order(Member member, DeliveryAddress deliveryAddress) {
+        this.member = member;
+        this.deliveryAddress = deliveryAddress;
+        this.status = OrderStatus.PENDING;
+        this.totalPrice = 0;
+    }
+
+    /**
+     * 주문 생성 정적 팩토리 메서드
+     */
+    public static Order createOrder(Member member, DeliveryAddress deliveryAddress) {
+        return Order.builder()
+                .member(member)
+                .deliveryAddress(deliveryAddress)
+                .build();
+    }
+
+    /**
+     * 주문 항목 추가 (양방향 연관관계 편의 메서드)
+     */
+    public void addOrderItem(OrderItem orderItem) {
+        this.orderItems.add(orderItem);
+        orderItem.setOrder(this);
+        this.totalPrice += orderItem.calculateTotalPrice();
+    }
+
+    /**
+     * 주문 취소 (상태만 변경, 재고 복구는 Service에서 처리)
+     */
+    public void cancel() {
+        if (this.status == OrderStatus.DELIVERED) {
+            throw new OrderException(OrderErrorCode.CANNOT_CANCEL_DELIVERED_ORDER);
+        }
+
+        this.status = OrderStatus.CANCELED;
+    }
+
+    /**
+     * 결제 완료 처리 및 Payment 연관관계 설정 (양방향 연관관계 편의 메서드)
+     */
+    public void completePayment(Payment payment) {
+        if (this.status != OrderStatus.PENDING) {
+            throw new OrderException(OrderErrorCode.INVALID_PAYMENT_COMPLETE_STATUS);
+        }
+        this.status = OrderStatus.PAID;
+        this.payment = payment;
+    }
+
+    /**
+     * 배송 시작 처리 (관리자)
+     */
+    public void ship() {
+        if (this.status != OrderStatus.PAID) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.status = OrderStatus.SHIPPED;
+    }
+
+    /**
+     * 배송 완료 처리 (관리자)
+     */
+    public void deliver() {
+        if (this.status != OrderStatus.SHIPPED) {
+            throw new OrderException(OrderErrorCode.INVALID_ORDER_STATUS);
+        }
+        this.status = OrderStatus.DELIVERED;
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/entity/OrderItem.java
@@ -1,0 +1,88 @@
+package com.prj.flashdeal.domain.order.entity;
+
+import com.prj.flashdeal.domain.product.entity.Product;
+import com.prj.flashdeal.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "order_item")
+public class OrderItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_item_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private int price; // 주문 시점의 상품 단가
+
+    @Column(nullable = false)
+    private int orderPrice; // 총 주문 금액 (price * quantity)
+
+    @Builder
+    private OrderItem(Order order, Product product, int quantity, int price) {
+        this.order = order;
+        this.product = product;
+        this.quantity = quantity;
+        this.price = price;
+        this.orderPrice = price * quantity;
+    }
+
+    /**
+     * 주문 항목 생성 정적 팩토리 메서드
+     */
+    public static OrderItem createOrderItem(Product product, int quantity) {
+        return OrderItem.builder()
+                .product(product)
+                .quantity(quantity)
+                .price(product.getPrice())
+                .build();
+    }
+
+    /**
+     * 주문과의 연관관계 설정 (Order.addOrderItem()에서만 호출)
+     */
+    protected void setOrder(Order order) {
+        this.order = order;
+    }
+
+    /**
+     * 총 주문 금액 계산
+     */
+    public int calculateTotalPrice() {
+        return this.price * this.quantity;
+    }
+
+    /**
+     * 상품 ID 반환 (재고 복구용)
+     */
+    public Long getProductId() {
+        return this.product.getId();
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/entity/OrderStatus.java
@@ -1,0 +1,17 @@
+package com.prj.flashdeal.domain.order.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderStatus {
+
+    PENDING("결제 대기"),
+    PAID("결제 완료"),
+    SHIPPED("배송 중"),
+    DELIVERED("배송 완료"),
+    CANCELED("주문 취소");
+
+    private final String description;
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/exception/OrderErrorCode.java
@@ -1,0 +1,24 @@
+package com.prj.flashdeal.domain.order.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+
+    ORDER_NOT_FOUND("주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_ORDER("본인의 주문만 조회할 수 있습니다.", HttpStatus.FORBIDDEN),
+    EMPTY_CART("장바구니가 비어있습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ORDER_STATUS("잘못된 주문 상태입니다.", HttpStatus.BAD_REQUEST),
+    CANNOT_CANCEL_DELIVERED_ORDER("배송 완료된 주문은 취소할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_STOCK("재고가 부족합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PAYMENT_COMPLETE_STATUS("대기 중인 주문만 결제 완료 처리할 수 있습니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/exception/OrderException.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/exception/OrderException.java
@@ -1,0 +1,10 @@
+package com.prj.flashdeal.domain.order.exception;
+
+import com.prj.flashdeal.global.exception.CustomException;
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+public class OrderException extends CustomException {
+    public OrderException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.prj.flashdeal.domain.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prj.flashdeal.domain.order.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,28 @@
+package com.prj.flashdeal.domain.order.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.prj.flashdeal.domain.member.entity.Member;
+import com.prj.flashdeal.domain.order.dto.response.OrderSummaryResponse;
+import com.prj.flashdeal.domain.order.entity.Order;
+
+public interface OrderRepositoryCustom {
+
+    Optional<Order> findByIdAndMemberId(Long orderId, Long memberId);
+
+    List<Order> findAllByMemberOrderByCreatedAtDesc(Member member);
+
+    /**
+     * 전체 주문 목록 조회 (관리자) - DTO Projection
+     */
+    Page<OrderSummaryResponse> findAllOrderSummaries(Pageable pageable);
+
+    /**
+     * 회원별 주문 목록 조회 - DTO Projection (페이징)
+     */
+    Page<OrderSummaryResponse> findOrderSummariesByMember(Member member, Pageable pageable);
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/repository/impl/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/repository/impl/OrderRepositoryCustomImpl.java
@@ -1,0 +1,103 @@
+package com.prj.flashdeal.domain.order.repository.impl;
+
+import static com.prj.flashdeal.domain.order.entity.QOrder.*;
+import static com.prj.flashdeal.domain.order.entity.QOrderItem.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.prj.flashdeal.domain.member.entity.Member;
+import com.prj.flashdeal.domain.order.dto.response.OrderSummaryResponse;
+import com.prj.flashdeal.domain.order.entity.Order;
+import com.prj.flashdeal.domain.order.repository.OrderRepositoryCustom;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Order> findByIdAndMemberId(Long orderId, Long memberId) {
+        Order result = queryFactory
+            .selectFrom(order)
+            .where(
+                order.id.eq(orderId),
+                order.member.id.eq(memberId)
+            )
+            .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public List<Order> findAllByMemberOrderByCreatedAtDesc(Member member) {
+        return queryFactory
+            .selectFrom(order)
+            .where(order.member.eq(member))
+            .orderBy(order.createdAt.desc())
+            .fetch();
+    }
+
+    @Override
+    public Page<OrderSummaryResponse> findAllOrderSummaries(Pageable pageable) {
+        List<OrderSummaryResponse> content = queryFactory
+            .select(Projections.constructor(OrderSummaryResponse.class,
+                order.id,
+                order.status,
+                order.totalPrice,
+                orderItem.count().intValue(),
+                order.createdAt
+            ))
+            .from(order)
+            .leftJoin(order.orderItems, orderItem)
+            .groupBy(order.id, order.status, order.totalPrice, order.createdAt)
+            .orderBy(order.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(order.count())
+            .from(order);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Page<OrderSummaryResponse> findOrderSummariesByMember(Member member, Pageable pageable) {
+        List<OrderSummaryResponse> content = queryFactory
+            .select(Projections.constructor(OrderSummaryResponse.class,
+                order.id,
+                order.status,
+                order.totalPrice,
+                orderItem.count().intValue(),
+                order.createdAt
+            ))
+            .from(order)
+            .leftJoin(order.orderItems, orderItem)
+            .where(order.member.eq(member))
+            .groupBy(order.id, order.status, order.totalPrice, order.createdAt)
+            .orderBy(order.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(order.count())
+            .from(order)
+            .where(order.member.eq(member));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/service/OrderService.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/service/OrderService.java
@@ -1,0 +1,169 @@
+package com.prj.flashdeal.domain.order.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prj.flashdeal.domain.cart.entity.CartItem;
+import com.prj.flashdeal.domain.cart.service.CartService;
+import com.prj.flashdeal.domain.member.entity.Member;
+import com.prj.flashdeal.domain.member.service.MemberService;
+import com.prj.flashdeal.domain.order.dto.request.OrderCreateRequest;
+import com.prj.flashdeal.domain.order.dto.response.OrderResponse;
+import com.prj.flashdeal.domain.order.dto.response.OrderSummaryResponse;
+import com.prj.flashdeal.domain.order.entity.DeliveryAddress;
+import com.prj.flashdeal.domain.order.entity.Order;
+import com.prj.flashdeal.domain.order.entity.OrderItem;
+import com.prj.flashdeal.domain.order.exception.OrderErrorCode;
+import com.prj.flashdeal.domain.order.exception.OrderException;
+import com.prj.flashdeal.domain.order.repository.OrderRepository;
+import com.prj.flashdeal.domain.product.entity.Product;
+import com.prj.flashdeal.domain.product.service.ProductService;
+import com.prj.flashdeal.global.response.PageResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final MemberService memberService;
+    private final CartService cartService;
+    private final ProductService productService;
+
+    /**
+     * 주문 생성 (장바구니 → 주문 전환)
+     */
+    @Transactional
+    public OrderResponse createOrder(Long memberId, OrderCreateRequest request) {
+        Member member = memberService.getMember(memberId);
+
+        // 장바구니 조회
+        List<CartItem> cartItems = cartService.getCartItemsForOrder(member);
+        if (cartItems.isEmpty()) {
+            throw new OrderException(OrderErrorCode.EMPTY_CART);
+        }
+
+        // 배송지 정보 생성
+        DeliveryAddress deliveryAddress = DeliveryAddress.of(
+            request.getRecipientName(),
+            request.getPhoneNumber(),
+            request.getZipcode(),
+            request.getStreet(),
+            request.getDetail()
+        );
+
+        // 주문 생성
+        Order order = Order.createOrder(member, deliveryAddress);
+
+        // 장바구니 항목 → 주문 항목 변환 및 재고 감소
+        for (CartItem cartItem : cartItems) {
+            Product product = cartItem.getProduct();
+
+            // 재고 감소 (ProductService 사용)
+            productService.decreaseStock(product.getId(), cartItem.getQuantity());
+
+            // 주문 항목 생성
+            OrderItem orderItem = OrderItem.createOrderItem(product, cartItem.getQuantity());
+            order.addOrderItem(orderItem);
+        }
+
+        // 주문 저장
+        Order savedOrder = orderRepository.save(order);
+
+        // 장바구니 비우기
+        cartService.clearCartForOrder(member);
+
+        return OrderResponse.from(savedOrder);
+    }
+
+    /**
+     * 주문 단건 조회
+     */
+    @Transactional(readOnly = true)
+    public OrderResponse getOrder(Long memberId, Long orderId) {
+        Order order = orderRepository.findByIdAndMemberId(orderId, memberId)
+            .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        return OrderResponse.from(order);
+    }
+
+    /**
+     * 주문 목록 조회 (DTO Projection, 페이징)
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<OrderSummaryResponse> getOrders(Long memberId, Pageable pageable) {
+        Member member = memberService.getMember(memberId);
+
+        Page<OrderSummaryResponse> responsePage = orderRepository.findOrderSummariesByMember(member, pageable);
+        return new PageResponse<>(responsePage);
+    }
+
+    /**
+     * 주문 취소
+     */
+    @Transactional
+    public void cancelOrder(Long memberId, Long orderId) {
+        Order order = orderRepository.findByIdAndMemberId(orderId, memberId)
+            .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // 주문 취소 (OrderException 발생 가능)
+        order.cancel();
+
+        // 재고 복구
+        for (OrderItem orderItem : order.getOrderItems()) {
+            productService.increaseStock(orderItem.getProductId(), orderItem.getQuantity());
+        }
+    }
+
+    /**
+     * 주문 조회 (내부 사용)
+     */
+    @Transactional(readOnly = true)
+    public Order findOrder(Long orderId) {
+        return orderRepository.findById(orderId)
+            .orElseThrow(() -> new OrderException(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+
+    // -------------------- 관리자 전용 메서드 --------------------
+
+    /**
+     * 전체 주문 목록 조회 (관리자) - 페이징 (DTO Projection)
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<OrderSummaryResponse> getAllOrders(Pageable pageable) {
+        Page<OrderSummaryResponse> responsePage = orderRepository.findAllOrderSummaries(pageable);
+        return new PageResponse<>(responsePage);
+    }
+
+    /**
+     * 주문 상세 조회 (관리자)
+     */
+    @Transactional(readOnly = true)
+    public OrderResponse getOrderForAdmin(Long orderId) {
+        Order order = findOrder(orderId);
+        return OrderResponse.from(order);
+    }
+
+    /**
+     * 배송 시작 처리 (관리자)
+     */
+    @Transactional
+    public void startShipping(Long orderId) {
+        Order order = findOrder(orderId);
+        order.ship();
+    }
+
+    /**
+     * 배송 완료 처리 (관리자)
+     */
+    @Transactional
+    public void completeDelivery(Long orderId) {
+        Order order = findOrder(orderId);
+        order.deliver();
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/entity/Product.java
@@ -72,6 +72,20 @@ public class Product extends BaseEntity {
         }
     }
 
+    public void removeStock(Integer quantity) {
+        if (quantity <= 0) {
+            throw new ProductException(ProductErrorCode.INVALID_STOCK_QUANTITY);
+        }
+        if (this.stockQuantity < quantity) {
+            throw new ProductException(ProductErrorCode.INVALID_STOCK_QUANTITY);
+        }
+        this.stockQuantity -= quantity;
+
+        if (this.stockQuantity == 0) {
+            this.status = ProductStatus.SOLD_OUT;
+        }
+    }
+
     public void updateInfo(String name, String description, Integer price) {
         if (name != null){
             if (name.isBlank()) {

--- a/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
+++ b/src/main/java/com/prj/flashdeal/domain/product/service/ProductService.java
@@ -111,6 +111,24 @@ public class ProductService {
         return product;
     }
 
+    /**
+     * 재고 감소 (주문 생성용)
+     */
+    @Transactional
+    public void decreaseStock(Long productId, int quantity) {
+        Product product = getProduct(productId);
+        product.removeStock(quantity);
+    }
+
+    /**
+     * 재고 복구 (주문 취소용)
+     */
+    @Transactional
+    public void increaseStock(Long productId, int quantity) {
+        Product product = getProduct(productId);
+        product.addStock(quantity);
+    }
+
     // ---------------- private 헬퍼 메서드 ----------------
     private Product getProduct(Long productId) {
         Product product = productRepository.findById(productId)


### PR DESCRIPTION
## 주요 기능
- 장바구니 → 주문 전환 (재고 감소 포함)
- 주문 조회 (단건/목록) - 페이지네이션 적용
- 주문 취소 (재고 복구 포함)
- 관리자 주문 관리 (목록 조회, 배송 처리)

## 엔티티
- Order: 주문 메인 엔티티
- OrderItem: 주문 상품 (스냅샷)
- DeliveryAddress: 배송지 정보 (Embedded)
- OrderStatus: PENDING, PAID, SHIPPED, DELIVERED, CANCELED

## API 엔드포인트
### 사용자
- POST /api/orders - 주문 생성
- GET /api/orders - 주문 목록 (페이징)
- GET /api/orders/{id} - 주문 조회
- DELETE /api/orders/{id} - 주문 취소

### 관리자
- GET /api/admin/orders - 전체 주문 목록 (페이징)
- GET /api/admin/orders/{id} - 주문 상세
- PATCH /api/admin/orders/{id}/ship - 배송 시작
- PATCH /api/admin/orders/{id}/deliver - 배송 완료

## 기술 구현
- QueryDSL DTO Projection으로 성능 최적화
- PageResponse 일관성 적용 (@PageableDefault(size=10))
- 트랜잭션 경계 명확화
- Member/Product 도메인과 연동

## 연관 도메인 수정
- Member: getMember() public 메서드 추가
- Product: 재고 증감 메서드 추가 (decreaseStock, increaseStock)