### PR TITLE
feat: 바로 구매(Direct Purchase) 기능 추가

### DIFF
--- a/src/main/java/com/prj/flashdeal/domain/order/controller/OrderController.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/controller/OrderController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prj.flashdeal.domain.order.dto.request.DirectOrderRequest;
 import com.prj.flashdeal.domain.order.dto.request.OrderCreateRequest;
 import com.prj.flashdeal.domain.order.dto.response.OrderResponse;
 import com.prj.flashdeal.domain.order.dto.response.OrderSummaryResponse;
@@ -32,17 +33,32 @@ public class OrderController {
     private final OrderService orderService;
 
     /**
-     * 주문 생성
+     * 장바구니에서 주문 생성
      */
-    @PostMapping
-    public ResponseEntity<ApiResponse<OrderResponse>> createOrder(
+    @PostMapping("/from-cart")
+    public ResponseEntity<ApiResponse<OrderResponse>> createOrderFromCart(
         @AuthenticationPrincipal UserPrincipal userPrincipal,
         @Valid @RequestBody OrderCreateRequest request
     ) {
         return ApiResponse.success(
             HttpStatus.CREATED,
             "주문이 생성되었습니다.",
-            orderService.createOrder(userPrincipal.getUserId(), request)
+            orderService.createOrderFromCart(userPrincipal.getUserId(), request)
+        );
+    }
+
+    /**
+     * 바로 구매 (장바구니 거치지 않음)
+     */
+    @PostMapping("/direct")
+    public ResponseEntity<ApiResponse<OrderResponse>> createDirectOrder(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @Valid @RequestBody DirectOrderRequest request
+    ) {
+        return ApiResponse.success(
+            HttpStatus.CREATED,
+            "바로 구매가 완료되었습니다.",
+            orderService.createDirectOrder(userPrincipal.getUserId(), request)
         );
     }
 

--- a/src/main/java/com/prj/flashdeal/domain/order/dto/request/DirectOrderRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/dto/request/DirectOrderRequest.java
@@ -1,0 +1,36 @@
+package com.prj.flashdeal.domain.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+/**
+ * 바로 구매 요청 DTO
+ */
+@Getter
+public class DirectOrderRequest {
+
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+    private Integer quantity;
+
+    @NotBlank(message = "수령인 이름은 필수입니다.")
+    private String recipientName;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^01[0-9]-\\d{3,4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다.")
+    private String phoneNumber;
+
+    @NotBlank(message = "우편번호는 필수입니다.")
+    private String zipcode;
+
+    @NotBlank(message = "도로명 주소는 필수입니다.")
+    private String street;
+
+    private String detail;
+}

--- a/src/main/java/com/prj/flashdeal/domain/order/service/OrderService.java
+++ b/src/main/java/com/prj/flashdeal/domain/order/service/OrderService.java
@@ -11,6 +11,7 @@ import com.prj.flashdeal.domain.cart.entity.CartItem;
 import com.prj.flashdeal.domain.cart.service.CartService;
 import com.prj.flashdeal.domain.member.entity.Member;
 import com.prj.flashdeal.domain.member.service.MemberService;
+import com.prj.flashdeal.domain.order.dto.request.DirectOrderRequest;
 import com.prj.flashdeal.domain.order.dto.request.OrderCreateRequest;
 import com.prj.flashdeal.domain.order.dto.response.OrderResponse;
 import com.prj.flashdeal.domain.order.dto.response.OrderSummaryResponse;
@@ -39,7 +40,7 @@ public class OrderService {
      * 주문 생성 (장바구니 → 주문 전환)
      */
     @Transactional
-    public OrderResponse createOrder(Long memberId, OrderCreateRequest request) {
+    public OrderResponse createOrderFromCart(Long memberId, OrderCreateRequest request) {
         Member member = memberService.getMember(memberId);
 
         // 장바구니 조회
@@ -77,6 +78,41 @@ public class OrderService {
 
         // 장바구니 비우기
         cartService.clearCartForOrder(member);
+
+        return OrderResponse.from(savedOrder);
+    }
+
+    /**
+     * 바로 구매 (장바구니 거치지 않고 즉시 주문)
+     */
+    @Transactional
+    public OrderResponse createDirectOrder(Long memberId, DirectOrderRequest request) {
+        Member member = memberService.getMember(memberId);
+
+        // 상품 조회 및 검증
+        Product product = productService.findCartableProduct(request.getProductId());
+
+        // 배송지 정보 생성
+        DeliveryAddress deliveryAddress = DeliveryAddress.of(
+            request.getRecipientName(),
+            request.getPhoneNumber(),
+            request.getZipcode(),
+            request.getStreet(),
+            request.getDetail()
+        );
+
+        // 주문 생성
+        Order order = Order.createOrder(member, deliveryAddress);
+
+        // 재고 감소
+        productService.decreaseStock(product.getId(), request.getQuantity());
+
+        // 주문 항목 생성
+        OrderItem orderItem = OrderItem.createOrderItem(product, request.getQuantity());
+        order.addOrderItem(orderItem);
+
+        // 주문 저장
+        Order savedOrder = orderRepository.save(order);
 
         return OrderResponse.from(savedOrder);
     }

--- a/src/main/java/com/prj/flashdeal/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/controller/PaymentController.java
@@ -1,0 +1,90 @@
+package com.prj.flashdeal.domain.payment.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prj.flashdeal.domain.payment.dto.request.PaymentRequest;
+import com.prj.flashdeal.domain.payment.dto.response.PaymentResponse;
+import com.prj.flashdeal.domain.payment.service.PaymentService;
+import com.prj.flashdeal.global.response.ApiResponse;
+import com.prj.flashdeal.global.security.dto.UserPrincipal;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    /**
+     * 결제 처리
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<PaymentResponse>> processPayment(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @Valid @RequestBody PaymentRequest request
+    ) {
+        return ApiResponse.success(
+            HttpStatus.CREATED,
+            "결제가 완료되었습니다.",
+            paymentService.processPayment(userPrincipal.getUserId(), request)
+        );
+    }
+
+    /**
+     * 결제 조회
+     */
+    @GetMapping("/{paymentId}")
+    public ResponseEntity<ApiResponse<PaymentResponse>> getPayment(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @PathVariable Long paymentId
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "결제 정보 조회가 완료되었습니다.",
+            paymentService.getPayment(userPrincipal.getUserId(), paymentId)
+        );
+    }
+
+    /**
+     * 주문 ID로 결제 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<PaymentResponse>> getPaymentByOrderId(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @RequestParam Long orderId
+    ) {
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "결제 정보 조회가 완료되었습니다.",
+            paymentService.getPaymentByOrderId(userPrincipal.getUserId(), orderId)
+        );
+    }
+
+    /**
+     * 환불 처리
+     */
+    @PostMapping("/{paymentId}/refund")
+    public ResponseEntity<ApiResponse<Void>> refundPayment(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @PathVariable Long paymentId
+    ) {
+        paymentService.refundPayment(userPrincipal.getUserId(), paymentId);
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "환불이 완료되었습니다.",
+            null
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/dto/request/PaymentRequest.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/dto/request/PaymentRequest.java
@@ -1,0 +1,23 @@
+package com.prj.flashdeal.domain.payment.dto.request;
+
+import com.prj.flashdeal.domain.payment.entity.PaymentMethod;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentRequest {
+
+    @NotNull(message = "주문 ID는 필수입니다.")
+    private Long orderId;
+
+    @NotNull(message = "결제 방법은 필수입니다.")
+    private PaymentMethod paymentMethod;
+
+    @NotNull(message = "결제 금액은 필수입니다.")
+    @Positive(message = "결제 금액은 0보다 커야 합니다.")
+    private Integer amount;
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/dto/response/PaymentResponse.java
@@ -1,0 +1,29 @@
+package com.prj.flashdeal.domain.payment.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.prj.flashdeal.domain.payment.entity.Payment;
+import com.prj.flashdeal.domain.payment.entity.PaymentMethod;
+import com.prj.flashdeal.domain.payment.entity.PaymentStatus;
+
+public record PaymentResponse(
+    Long paymentId,
+    Long orderId,
+    PaymentStatus status,
+    PaymentMethod method,
+    Integer amount,
+    LocalDateTime paidAt,
+    LocalDateTime createdAt
+) {
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+            payment.getId(),
+            payment.getOrder().getId(),
+            payment.getStatus(),
+            payment.getMethod(),
+            payment.getAmount(),
+            payment.getPaidAt(),
+            payment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/entity/Payment.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/entity/Payment.java
@@ -1,0 +1,71 @@
+package com.prj.flashdeal.domain.payment.entity;
+
+import java.time.LocalDateTime;
+
+import com.prj.flashdeal.domain.order.entity.Order;
+import com.prj.flashdeal.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment")
+public class Payment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod method;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    private LocalDateTime paidAt;
+
+    @Builder
+    public Payment(Order order, Integer amount) {
+        this.order = order;
+        this.amount = amount;
+        this.status = PaymentStatus.PENDING;
+    }
+
+    public void completePayment(PaymentMethod method) {
+        this.status = PaymentStatus.COMPLETED;
+        this.method = method;
+        this.paidAt = LocalDateTime.now();
+    }
+
+    public void failPayment() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    public void refund() {
+        this.status = PaymentStatus.REFUNDED;
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/entity/PaymentMethod.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/entity/PaymentMethod.java
@@ -1,0 +1,14 @@
+package com.prj.flashdeal.domain.payment.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentMethod {
+    CARD("카드"),
+    CASH("현금"),
+    TRANSFER("계좌이체");
+
+    private final String description;
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,15 @@
+package com.prj.flashdeal.domain.payment.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+    PENDING("결제 대기"),
+    COMPLETED("결제 완료"),
+    FAILED("결제 실패"),
+    REFUNDED("환불 완료");
+
+    private final String description;
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,24 @@
+package com.prj.flashdeal.domain.payment.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+
+    PAYMENT_NOT_FOUND("결제 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    PAYMENT_ALREADY_COMPLETED("이미 완료된 결제입니다.", HttpStatus.BAD_REQUEST),
+    PAYMENT_ALREADY_FAILED("이미 실패한 결제입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PAYMENT_STATUS("잘못된 결제 상태입니다.", HttpStatus.BAD_REQUEST),
+    PAYMENT_AMOUNT_MISMATCH("결제 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    ORDER_NOT_FOUND("주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED_ORDER("본인의 주문만 접근할 수 있습니다.", HttpStatus.FORBIDDEN);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/exception/PaymentException.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/exception/PaymentException.java
@@ -1,0 +1,10 @@
+package com.prj.flashdeal.domain.payment.exception;
+
+import com.prj.flashdeal.global.exception.CustomException;
+import com.prj.flashdeal.global.exception.ErrorCode;
+
+public class PaymentException extends CustomException {
+    public PaymentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,8 @@
+package com.prj.flashdeal.domain.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prj.flashdeal.domain.payment.entity.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long>, PaymentRepositoryCustom {
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/repository/PaymentRepositoryCustom.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/repository/PaymentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.prj.flashdeal.domain.payment.repository;
+
+import java.util.Optional;
+
+import com.prj.flashdeal.domain.payment.entity.Payment;
+
+public interface PaymentRepositoryCustom {
+
+    Optional<Payment> findByOrderId(Long orderId);
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/repository/impl/PaymentRepositoryCustomImpl.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/repository/impl/PaymentRepositoryCustomImpl.java
@@ -1,0 +1,30 @@
+package com.prj.flashdeal.domain.payment.repository.impl;
+
+import static com.prj.flashdeal.domain.payment.entity.QPayment.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.prj.flashdeal.domain.payment.entity.Payment;
+import com.prj.flashdeal.domain.payment.repository.PaymentRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryCustomImpl implements PaymentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Payment> findByOrderId(Long orderId) {
+        Payment result = queryFactory
+            .selectFrom(payment)
+            .where(payment.order.id.eq(orderId))
+            .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/prj/flashdeal/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/prj/flashdeal/domain/payment/service/PaymentService.java
@@ -1,0 +1,115 @@
+package com.prj.flashdeal.domain.payment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prj.flashdeal.domain.order.entity.Order;
+import com.prj.flashdeal.domain.order.service.OrderService;
+import com.prj.flashdeal.domain.payment.dto.request.PaymentRequest;
+import com.prj.flashdeal.domain.payment.dto.response.PaymentResponse;
+import com.prj.flashdeal.domain.payment.entity.Payment;
+import com.prj.flashdeal.domain.payment.exception.PaymentErrorCode;
+import com.prj.flashdeal.domain.payment.exception.PaymentException;
+import com.prj.flashdeal.domain.payment.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final OrderService orderService;
+
+    /**
+     * 결제 처리
+     */
+    @Transactional
+    public PaymentResponse processPayment(Long memberId, PaymentRequest request) {
+        // 주문 조회 및 권한 검증
+        Order order = orderService.findOrder(request.getOrderId());
+
+        if (!order.getMember().getId().equals(memberId)) {
+            throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_ORDER);
+        }
+
+        // 이미 결제가 존재하는지 확인
+        paymentRepository.findByOrderId(order.getId())
+            .ifPresent(payment -> {
+                throw new PaymentException(PaymentErrorCode.PAYMENT_ALREADY_COMPLETED);
+            });
+
+        // 결제 금액 검증 (보안: 클라이언트가 보낸 금액과 실제 주문 금액 일치 확인)
+        if (!request.getAmount().equals(order.getTotalPrice())) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        // 결제 생성
+        Payment payment = Payment.builder()
+            .order(order)
+            .amount(request.getAmount())
+            .build();
+
+        // 결제 완료 처리
+        payment.completePayment(request.getPaymentMethod());
+
+        // 주문 상태 변경 (PENDING → PAID) 및 양방향 연관관계 설정
+        order.completePayment(payment);
+
+        Payment savedPayment = paymentRepository.save(payment);
+
+        return PaymentResponse.from(savedPayment);
+    }
+
+    /**
+     * 결제 조회
+     */
+    @Transactional(readOnly = true)
+    public PaymentResponse getPayment(Long memberId, Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        // 권한 검증
+        if (!payment.getOrder().getMember().getId().equals(memberId)) {
+            throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_ORDER);
+        }
+
+        return PaymentResponse.from(payment);
+    }
+
+    /**
+     * 주문 ID로 결제 조회
+     */
+    @Transactional(readOnly = true)
+    public PaymentResponse getPaymentByOrderId(Long memberId, Long orderId) {
+        Payment payment = paymentRepository.findByOrderId(orderId)
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        // 권한 검증
+        if (!payment.getOrder().getMember().getId().equals(memberId)) {
+            throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_ORDER);
+        }
+
+        return PaymentResponse.from(payment);
+    }
+
+    /**
+     * 환불 처리 (OrderService를 통한 주문 취소)
+     */
+    @Transactional
+    public void refundPayment(Long memberId, Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        // 권한 검증
+        if (!payment.getOrder().getMember().getId().equals(memberId)) {
+            throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_ORDER);
+        }
+
+        // 환불 처리
+        payment.refund();
+
+        // 주문 취소 (OrderService를 통한 재고 복구)
+        orderService.cancelOrder(memberId, payment.getOrder().getId());
+    }
+}


### PR DESCRIPTION
## 주요 기능
- 장바구니를 거치지 않고 상품을 즉시 주문 가능
- 기존 장바구니 주문과 바로 구매 분리

## API 변경사항
### 기존 (변경)
- POST /api/orders → POST /api/orders/from-cart (장바구니 주문)

### 신규
- POST /api/orders/direct (바로 구매)

## 구현 내용
- DirectOrderRequest DTO 추가 (상품ID + 수량 + 배송지)
- OrderService.createDirectOrder() 메서드 추가
- OrderService.createOrder() → createOrderFromCart()로 메서드명 변경
- OrderController에 두 가지 주문 엔드포인트 제공

## 장점
- 빠른 구매 경험 제공
- 사용자 편의성 향상
- 실제 이커머스와 동일한 UX